### PR TITLE
refactor: use get_token from re_unplayplay

### DIFF
--- a/votify/downloader.py
+++ b/votify/downloader.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 try:
     re_unpp_exc: ImportError | None = None
-    from re_unplayplay import decrypt_and_bind_key
+    from re_unplayplay import decrypt_and_bind_key, get_token
 except ImportError as err:
     decrypt_and_bind_key = lambda a, b: None
+    get_token = lambda: None
     re_unpp_exc = err
 
 import requests
@@ -369,7 +370,7 @@ class Downloader:
     def get_playplay_decryption_key(self, file_id: str) -> bytes:
         playplay_license_request = PlayPlayLicenseRequest(
             version=2,
-            token=bytes.fromhex("01e132cae527bd21620e822f58514932"),
+            token=get_token(),
             interactivity=Interactivity.INTERACTIVE,
             content_type=AUDIO_TRACK,
         )


### PR DESCRIPTION
Since v1.2.2, re_unplayplay exports a function get_token to retrieve the associated token. 

Can be merged once this is green https://github.com/es3n1n/re-unplayplay/actions/runs/11095559745 