### PR TITLE
Update authorization endpoints and TOTP

### DIFF
--- a/votify/spotify_api.py
+++ b/votify/spotify_api.py
@@ -77,12 +77,12 @@ class SpotifyApi:
         self._set_user_profile()
 
     def _set_session_info(self):
-        server_time_response = self.session.get("https://open.spotify.com/server-time")
+        server_time_response = self.session.get("https://open.spotify.com/api/server-time")
         check_response(server_time_response)
         server_time = 1e3 * server_time_response.json()["serverTime"]
         totp = self.totp.generate(timestamp=server_time)
         session_info_response = self.session.get(
-            "https://open.spotify.com/get_access_token",
+            "https://open.spotify.com/api/token",
             params={
                 "reason": "init",
                 "productType": "web-player",

--- a/votify/totp.py
+++ b/votify/totp.py
@@ -6,8 +6,8 @@ import math
 class TOTP:
     def __init__(self) -> None:
         # dumped directly from the object, after all decryptions
-        self.secret = b"5507145853487499592248630329347"
-        self.version = 5
+        self.secret = b"449443649084886328893534571041315"
+        self.version = 8
         self.period = 30
         self.digits = 6
 


### PR DESCRIPTION
Spotify has changed the endpoints required for accessToken, the TOTP secret and its version.