### PR TITLE
Add `--download-archive` and `--break-on-existing` features

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ votify [OPTIONS] URLS...
   ```bash
   votify "https://open.spotify.com/artist/0gxyHStUsqpMadRV0Di1Qt"
   ```
+- Incremental sync of a regularly updated podcast or playlist
+  ```bash
+  votify --download-archive archive.txt --break-on-existing "https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk"
+  ```
 
 ### Interactive prompt controls
 
@@ -155,6 +159,8 @@ Config file values can be overridden using command-line arguments.
 | `--save-cover` / `save_cover`                                   | Save cover as a separate file.                                     | `false`                                        |
 | `--save-playlist` / `save_playlist`                             | Save a M3U8 playlist file when downloading a playlist.             | `false`                                        |
 | `--overwrite` / `overwrite`                                     | Overwrite existing files.                                          | `false`                                        |
+| `--download-archive` / `download_archive`                       | Path to download archive file to record downloaded items.          | `null`                                         |
+| `--break-on-existing` / `break_on_existing`                     | Stop downloading when a media item that has already been downloaded is encountered. | `false`                                        |
 | `--exclude-tags` / `exclude_tags`                               | Comma-separated tags to exclude.                                   | `null`                                         |
 | `--truncate` / `truncate`                                       | Maximum length of the file/folder names.                           | `null`                                         |
 | `--audio-quality`, `-a` / `audio_quality`                       | Audio quality for songs and podcasts.                              | `aac-medium`                                   |
@@ -234,6 +240,24 @@ The following variables can be used in the template folder/file and/or in the `e
 - `ffmpeg`
 - `mp4box`
 - `mp4decrypt`
+
+### Download Archive
+
+Votify supports download archives to avoid re-downloading the same content, similar to _yt-dlp_'s functionality.
+
+#### How it works
+
+- When `--download-archive` is specified, Votify records the Spotify ID of each successfully downloaded item in the specified archive file;
+- Before downloading, Votify checks if the item already exists as a file or is recorded in the archive;
+- If either condition is true, the item is skipped.
+
+#### Break on existing
+
+The `--break-on-existing` option stops the download process when encountering an already-downloaded item. This is useful for downloading new episodes of a podcast or new songs in a playlist without ploughing through the entire list.
+
+```bash
+votify --download-archive archive.txt --break-on-existing "https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk"
+```
 
 ### Credits
 

--- a/votify/cli.py
+++ b/votify/cli.py
@@ -35,6 +35,7 @@ from .enums import (
     VideoFormat,
 )
 from .spotify_api import SpotifyApi
+from .models import BreakOnExistingException
 from .utils import color_text, prompt_path
 
 logger = logging.getLogger("votify")
@@ -284,6 +285,17 @@ def load_config_file(
     help="Overwrite existing files.",
 )
 @click.option(
+    "--download-archive",
+    type=Path,
+    default=None,
+    help="Path to download archive file to record downloaded items.",
+)
+@click.option(
+    "--break-on-existing",
+    is_flag=True,
+    help="Stop downloading when a media item that has already been downloaded is encountered.",
+)
+@click.option(
     "--exclude-tags",
     type=str,
     default=downloader_sig.parameters["exclude_tags"].default,
@@ -393,6 +405,8 @@ def main(
     video_format: VideoFormat,
     remux_mode_video: RemuxModeVideo,
     no_config_file: bool,
+    download_archive: Path,
+    break_on_existing: bool,
 ) -> None:
     colorama.just_fix_windows_console()
     logger.setLevel(log_level)
@@ -428,6 +442,8 @@ def main(
         overwrite,
         exclude_tags,
         truncate,
+        download_archive,
+        break_on_existing,
     )
     downloader_audio = DownloaderAudio(
         downloader,
@@ -607,6 +623,10 @@ def main(
                             playlist_metadata=download_queue_item.playlist_metadata,
                             playlist_track=index,
                         )
+            except BreakOnExistingException as e:
+                logger.info(f'({queue_progress}) {str(e)}')
+                logger.info("Stopping due to --break-on-existing")
+                return
             except Exception as e:
                 error_count += 1
                 logger.error(

--- a/votify/downloader_episode.py
+++ b/votify/downloader_episode.py
@@ -120,8 +120,11 @@ class DownloaderEpisode(DownloaderAudio):
         )
         decrypted_path = None
         remuxed_path = None
-        if final_path.exists() and not self.downloader.overwrite:
-            logger.warning(f'Track already exists at "{final_path}", skipping')
+        if self.downloader.check_existing_file_or_archive(final_path, episode_id):
+            if final_path.exists():
+                logger.warning(f'Episode already exists at "{final_path}", skipping')
+            else:
+                logger.warning(f'Episode {episode_id} already in download archive, skipping')
         else:
             decryption_key = (
                 self.DEFAULT_EPISODE_DECRYPTION_KEY.hex()
@@ -167,4 +170,5 @@ class DownloaderEpisode(DownloaderAudio):
             tags,
             playlist_metadata,
             playlist_track,
+            episode_id,
         )

--- a/votify/downloader_episode_video.py
+++ b/votify/downloader_episode_video.py
@@ -83,8 +83,11 @@ class DownloaderEpisodeVideo(DownloaderVideo):
             COVER_SIZE_X_KEY_MAPPING_EPISODE,
         )
         remuxed_path = None
-        if final_path.exists() and not self.downloader.overwrite:
-            logger.warning(f'Episode already exists at "{final_path}", skipping')
+        if self.downloader.check_existing_file_or_archive(final_path, episode_id):
+            if final_path.exists():
+                logger.warning(f'Episode already exists at "{final_path}", skipping')
+            else:
+                logger.warning(f'Episode {episode_id} already in download archive, skipping')
             return
         else:
             key_id, decryption_key = (
@@ -150,4 +153,5 @@ class DownloaderEpisodeVideo(DownloaderVideo):
             tags,
             playlist_metadata,
             playlist_track,
+            episode_id,
         )

--- a/votify/downloader_music_video.py
+++ b/votify/downloader_music_video.py
@@ -195,8 +195,11 @@ class DownloaderMusicVideo(DownloaderVideo):
             COVER_SIZE_X_KEY_MAPPING_VIDEO,
         )
         remuxed_path = None
-        if final_path.exists() and not self.downloader.overwrite:
-            logger.warning(f'Music video already exists at "{final_path}", skipping')
+        if self.downloader.check_existing_file_or_archive(final_path, music_video_id):
+            if final_path.exists():
+                logger.warning(f'Music video already exists at "{final_path}", skipping')
+            else:
+                logger.warning(f'Music video {music_video_id} already in download archive, skipping')
             return
         else:
             key_id, decryption_key = self.downloader.get_widevine_decryption_key(
@@ -253,4 +256,5 @@ class DownloaderMusicVideo(DownloaderVideo):
             tags,
             playlist_metadata,
             playlist_track,
+            music_video_id,
         )

--- a/votify/downloader_song.py
+++ b/votify/downloader_song.py
@@ -212,8 +212,11 @@ class DownloaderSong(DownloaderAudio):
         remuxed_path = None
         if self.lrc_only:
             pass
-        elif final_path.exists() and not self.downloader.overwrite:
-            logger.warning(f'Track already exists at "{final_path}", skipping')
+        elif self.downloader.check_existing_file_or_archive(final_path, track_id):
+            if final_path.exists():
+                logger.warning(f'Track already exists at "{final_path}", skipping')
+            else:
+                logger.warning(f'Track {track_id} already in download archive, skipping')
         else:
             if not decryption_key:
                 logger.debug("Getting decryption key")
@@ -264,4 +267,5 @@ class DownloaderSong(DownloaderAudio):
             tags,
             playlist_metadata,
             playlist_track,
+            track_id,
         )

--- a/votify/models.py
+++ b/votify/models.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 from .enums import AudioQuality
 
 
+class BreakOnExistingException(Exception):
+    """Exception raised when break-on-existing is triggered."""
+    pass
+
+
 @dataclass
 class Lyrics:
     synced: str = None


### PR DESCRIPTION
This adds `--download-archive` and `--break-on-existing` similar to _yt-dlp_, mainly for incremental podcast downloads.

`--download-archive` will record which IDs have been downloaded, and then check to see if IDs have been previously downloaded, rather than relying on the file existing and not being renamed or moved.

`--break-on-existing` will stop the run if an item that has been previously downloaded, either using the archive file or if the file already exists.  That way, once it finds an item it's already downloaded it doesn't need to bother checking the rest of the podcast/playlist/whatever.