### PR TITLE
upgrade totp secret and version value to the newest version

### DIFF
--- a/votify/totp.py
+++ b/votify/totp.py
@@ -6,8 +6,8 @@ import math
 class TOTP:
     def __init__(self) -> None:
         # dumped directly from the object, after all decryptions
-        self.secret = b"10239356982684469120121471223494829410773366870"
-        self.version = 11
+        self.secret = b"55601029510267381196079975060119874370686866"
+        self.version = 14
         self.period = 30
         self.digits = 6
 


### PR DESCRIPTION
<img width="2406" height="1052" alt="image" src="https://github.com/user-attachments/assets/ce825b6c-b037-48a0-baac-0ef9753fd059" />
<img width="2534" height="1156" alt="image" src="https://github.com/user-attachments/assets/4794ddff-74d4-4246-9ec5-8fe8aa034e5c" />
<img width="2718" height="408" alt="image" src="https://github.com/user-attachments/assets/69411cd7-51d9-42c2-8980-8185a1f760cd" />


As we can see from the /api/token request, totp algorithm has been upgraded to version 14 and the secret value has been changed