### PR TITLE
Added retry option with `--max-retries` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Config file values can be overridden using command-line arguments.
 | `--config-path` / -                                             | Path to config file.                                               | `<home>/.spotify-web-downloader/config.json`   |
 | `--log-level` / `log_level`                                     | Log level.                                                         | `INFO`                                         |
 | `--no-exceptions` / `no_exceptions`                             | Don't print exceptions.                                            | `false`                                        |
+| `--max-retries` / `max_retries`                                 | Maximum retry attempts for failed downloads due to exceptions.     | `0`                                            |
 | `--cookies-path` / `cookies_path`                               | Path to cookies file.                                              | `cookies.txt`                                  |
 | `--output-path`, `-o` / `output_path`                           | Path to output directory.                                          | `Spotify`                                      |
 | `--temp-path` / `temp_path`                                     | Path to temporary directory.                                       | `temp`                                         |

--- a/votify/cli.py
+++ b/votify/cli.py
@@ -147,6 +147,12 @@ def load_config_file(
     help="Don't print exceptions.",
 )
 @click.option(
+    "--max-retries",
+    type=int,
+    default=0,
+    help="Maximum retry attempts for failed downloads due to exceptions."
+)
+@click.option(
     "--cookies-path",
     type=Path,
     default=Path("./cookies.txt"),
@@ -360,6 +366,7 @@ def main(
     config_path: Path,
     log_level: str,
     no_exceptions: bool,
+    max_retries: int,
     cookies_path: Path,
     output_path: Path,
     temp_path: Path,
@@ -544,7 +551,10 @@ def main(
                 exc_info=no_exceptions,
             )
             continue
-        for index, download_queue_item in enumerate(download_queue, start=1):
+        retry_count = 0
+        index = 1
+        while index <= len(download_queue):
+            download_queue_item = download_queue[index - 1]
             queue_progress = color_text(
                 f"Track {index}/{len(download_queue)} from URL {url_index}/{len(urls)}",
                 colorama.Style.DIM,
@@ -607,12 +617,21 @@ def main(
                             playlist_metadata=download_queue_item.playlist_metadata,
                             playlist_track=index,
                         )
+                retry_count = 0
+                index += 1
             except Exception as e:
                 error_count += 1
                 logger.error(
                     f'({queue_progress}) Failed to download "{media_metadata["name"]}"',
                     exc_info=not no_exceptions,
                 )
+                if retry_count < max_retries:
+                    retry_count += 1
+                    logger.info(
+                        f'({queue_progress}) Queued retry {retry_count}/{max_retries} of "{media_metadata["name"]}"'
+                    )
+                else:
+                    index += 1
             finally:
                 if wait_interval > 0 and index != len(download_queue):
                     logger.debug(


### PR DESCRIPTION
Adds an option to retry downloads that fail due to an exception.

