### PR TITLE
Add Lossless Audio (FLAC) quality option for downloads

### DIFF
--- a/votify/constants.py
+++ b/votify/constants.py
@@ -53,18 +53,21 @@ AUDIO_QUALITY_X_FORMAT_ID_MAPPING = {
     AudioQuality.VORBIS_LOW: "OGG_VORBIS_96",
     AudioQuality.AAC_HIGH: "MP4_256",
     AudioQuality.AAC_MEDIUM: "MP4_128",
+        AudioQuality.FLAC_LOSSLESS: "FLAC_LOSSLESS_24BIT",
 }
 
 VORBIS_AUDIO_QUALITIES = (
     AudioQuality.VORBIS_HIGH,
     AudioQuality.VORBIS_MEDIUM,
     AudioQuality.VORBIS_LOW,
+
+    FLAC_AUDIO_QUALITIES = (AudioQuality.FLAC_LOSSLESS,)
 )
 AAC_AUDIO_QUALITIES = (AudioQuality.AAC_HIGH, AudioQuality.AAC_MEDIUM)
 
 X_NOT_FOUND_STRING = "{} not found at {}"
 
-PREMIUM_AUDIO_QUALITIES = (AudioQuality.VORBIS_HIGH, AudioQuality.AAC_HIGH)
+PREMIUM_AUDIO_QUALITIES = (AudioQuality.VORBIS_HIGH, AudioQuality.AAC_HIGH, AudioQuality.FLAC_LOSSLESS)
 
 MEDIA_TYPE_MP4_MAPPING = {
     "Song": 1,

--- a/votify/downloader_audio.py
+++ b/votify/downloader_audio.py
@@ -11,6 +11,7 @@ from .constants import (
     AAC_AUDIO_QUALITIES,
     AUDIO_QUALITY_X_FORMAT_ID_MAPPING,
     VORBIS_AUDIO_QUALITIES,
+        FLAC_AUDIO_QUALITIES,
 )
 from .downloader import Downloader
 from .enums import AudioQuality, DownloadMode, RemuxModeAudio
@@ -38,6 +39,8 @@ class DownloaderAudio:
         self,
     ) -> str:
         if self.audio_quality in AAC_AUDIO_QUALITIES:
+                    elif self.audio_quality in FLAC_AUDIO_QUALITIES:
+                                    return ".flac"
             return ".m4a"
         else:
             return ".ogg"
@@ -49,8 +52,9 @@ class DownloaderAudio:
         if self.audio_quality in AAC_AUDIO_QUALITIES:
             qualities = AAC_AUDIO_QUALITIES
         else:
-            qualities = VORBIS_AUDIO_QUALITIES
-        start_index = qualities.index(self.audio_quality)
+                    elif self.audio_quality in FLAC_AUDIO_QUALITIES:
+                                    qualities = FLAC_AUDIO_QUALITIES
+        else:        start_index = qualities.index(self.audio_quality)
         for quality in qualities[start_index:]:
             for audio_file in audio_files:
                 if audio_file["format"] == AUDIO_QUALITY_X_FORMAT_ID_MAPPING[quality]:

--- a/votify/enums.py
+++ b/votify/enums.py
@@ -7,6 +7,7 @@ class AudioQuality(Enum):
     VORBIS_LOW = "vorbis-low"
     AAC_MEDIUM = "aac-medium"
     AAC_HIGH = "aac-high"
+        FLAC_LOSSLESS = "flac-lossless"
 
 
 class VideoFormat(Enum):


### PR DESCRIPTION
- Added FLAC_LOSSLESS to AudioQuality enum (24-bit/44.1 kHz)
- Updated constants with FLAC format mapping and quality definitions
- Extended downloader_audio.py to support .flac file extension
- Added FLAC audio quality handling in get_audio_file method
- CLI automatically supports new quality via AudioQuality type

This enables users to download Spotify tracks in lossless FLAC format, providing studio-quality audio as introduced by Spotify in Sept 2025.