### PR TITLE
Add --limit option to cap URLs processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The file is created automatically on first run. Command-line arguments override 
 | `--no-exceptions` / `no_exceptions` | Don't print exceptions | `false` |
 | `--no-config-file`, `-n` / - | Don't use a config file | `false` |
 | `--database-path` / `database_path` | Path to the SQLite database file for registering downloaded media | `null` |
+| `--limit` / `limit` | Maximum number of URLs to process | `null` |
 | `--auto-media-option` / `auto_media_option` | Auto media option | `null` |
 | **Spotify** | | |
 | `--session-type` / `session_type` | Session type to use | `librespot` |

--- a/votify/cli/cli.py
+++ b/votify/cli/cli.py
@@ -204,6 +204,9 @@ async def main(config: CliConfig):
 
     error_count = 0
     for url_index, url in enumerate(urls, 1):
+        if config.limit is not None and url_index > config.limit:
+            logger.info(f"Reached limit of {config.limit} URL(s), stopping")
+            break
         url_progress = click.style(f"[URL {url_index}/{len(urls)}]", dim=True)
         logger.info(url_progress + f' Processing "{url}"')
         download_queue = downloader.get_download_item(url, config.auto_media_option)

--- a/votify/cli/cli_config.py
+++ b/votify/cli/cli_config.py
@@ -126,6 +126,14 @@ class CliConfig:
             ),
         ),
     ]
+    limit: Annotated[
+        int | None,
+        option(
+            "--limit",
+            help="Maximum number of URLs to process",
+            default=None,
+        ),
+    ]
     # API specific options
     session_type: Annotated[
         SessionType,


### PR DESCRIPTION
## Summary
- Adds a `--limit N` / `limit` option that stops the URL-processing loop after N URLs.
- Most useful for batching large input files when combined with `--database-path` to avoid Spotify's anti-abuse rate limits on long runs.
- No behavioral change when the flag is unset (default `null` = unlimited).

## Motivation
On a 450-URL input, the run hit `Client token request failed with status code 400` after ~100 successful tracks — matching the account-suspension warning already in the README. With `--limit 50 --database-path downloaded.db --wait-interval 30`, a large job can be split across sessions: failures aren't recorded in the DB so they're retried automatically; successes are skipped. This makes very long input lists practical without tripping Spotify's abuse detection.

Implementation is intentionally minimal: +12 lines across the CLI config dataclass, the outer URL loop in `cli.main`, and the README options table. Nothing in the API, interface, or downloader layers is touched.

## Test plan
- [x] `votify --help` shows `--limit INTEGER` with the new help text in the General group.
- [x] Loop break logic verified for `limit ∈ {None, 0, 1, 3, 5, 99}` against a 5-URL list — all edge cases behave correctly (no break, break before first iteration, break mid-list, exact boundary, value greater than total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)